### PR TITLE
Add individual extractor support

### DIFF
--- a/server/server.default.properties
+++ b/server/server.default.properties
@@ -56,11 +56,12 @@ mappingsTestExtractors=.LabelExtractor,.MappingExtractor
 
 # Default extractors for all languages
 extractors=.LabelExtractor,.PageIdExtractor,.RevisionIdExtractor,.WikiPageOutDegreeExtractor,.WikiPageLengthExtractor,\
-.MappingExtractor,.GeoExtractor,.HtmlAbstractExtractor,.ArticlePageExtractor,\
+.MappingExtractor,.GeoExtractor,.ArticlePageExtractor,\
 .ArticleCategoriesExtractor,.CategoryLabelExtractor,.SkosCategoriesExtractor,.ArticleTemplatesExtractor,\
 .ExternalLinksExtractor,.ProvenanceExtractor,\
 .InfoboxExtractor
 #  #,.PageLinksExtractor,
+# .HtmlAbstractExtractor,
 # .InterLanguageLinksExtractor, Wikipedia moved interlanguage links to Wikidata (2012?2013)
 
 extractors.ar=.TopicalConceptsExtractor
@@ -69,13 +70,15 @@ extractors.ca=.DisambiguationExtractor,.HomepageExtractor,\
 .TopicalConceptsExtractor
 
 extractors.de=.DisambiguationExtractor,.HomepageExtractor,\
-.PersondataExtractor,.PndExtractor,.ImageExtractorNew,.DisambiguationExtractor
+.PersondataExtractor,.PndExtractor,.ImageExtractorNew
+# .PndExtractor, The German PND identifier system was replaced by GND in 2012
 
 extractors.el=.DisambiguationExtractor,.HomepageExtractor,\
 .TopicalConceptsExtractor
 
 extractors.en=.DisambiguationExtractor,.HomepageExtractor,\
-.PersondataExtractor,.PndExtractor,.TopicalConceptsExtractor,.ImageExtractorNew,.DisambiguationExtractor
+.PersondataExtractor,.PndExtractor,.TopicalConceptsExtractor,.ImageExtractorNew
+#.PersondataExtractor, The {{Persondata}} template was removed (2014?2017) since Wikidata made it redundant
 
 extractors.es=.DisambiguationExtractor,.HomepageExtractor,\
 .TopicalConceptsExtractor

--- a/server/src/main/scala/org/dbpedia/extraction/server/Server.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/Server.scala
@@ -2,7 +2,6 @@ package org.dbpedia.extraction.server
 
 import java.net.{URI, URL}
 import java.util.logging.Logger
-import java.util.concurrent.TimeUnit
 
 import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import com.sun.jersey.api.container.httpserver.HttpServerFactory
@@ -44,35 +43,36 @@ class Server(
   private case class ExtractorCacheKey(language: Language, extractorClass: Class[_ <: Extractor[_]])
 
   // Guava LoadingCache for single extractor managers with proper cache loader
-private val singleExtractorCache: LoadingCache[ExtractorCacheKey, ExtractionManager] = {
-  CacheBuilder.newBuilder()
-    .maximumSize(100)
-    //.expireAfterAccess(10, TimeUnit.MINUTES)
-    .build(new CacheLoader[ExtractorCacheKey, ExtractionManager]() {
-      override def load(key: ExtractorCacheKey): ExtractionManager = {
-        val manager = new DynamicExtractionManager(
-          managers(_).updateStats(_),
-          Seq(key.language),
-          paths,
-          redirects,
-          if (mappingTestExtractors.contains(key.extractorClass)) Seq(key.extractorClass) else Seq.empty,
-          if (customTestExtractors.getOrElse(key.language, Seq.empty).contains(key.extractorClass))
-            Map(key.language -> Seq(key.extractorClass)) else Map.empty
-        )
+  private val singleExtractorCache: LoadingCache[ExtractorCacheKey, ExtractionManager] = {
+    CacheBuilder.newBuilder()
+      .maximumSize(200)
+      //.expireAfterAccess(10, TimeUnit.MINUTES)
+      .build(new CacheLoader[ExtractorCacheKey, ExtractionManager]() {
+        override def load(key: ExtractorCacheKey): ExtractionManager = {
+          val manager = new DynamicExtractionManager(
+            managers(_).updateStats(_),
+            Seq(key.language),
+            paths,
+            redirects,
+            if (mappingTestExtractors.contains(key.extractorClass)) Seq(key.extractorClass) else Seq.empty,
+            if (customTestExtractors.getOrElse(key.language, Seq.empty).contains(key.extractorClass))
+              Map(key.language -> Seq(key.extractorClass)) else Map.empty
+          )
 
-        // ADD ERROR HANDLING HERE:
-        try {
-          manager.updateAll
-          manager
-        } catch {
-          case e: Exception =>
-            logger.warning(s"Failed to initialize extraction manager for ${key.extractorClass.getSimpleName} in ${key.language.wikiCode}: ${e.getMessage}")
-            // Return a manager without calling updateAll to avoid mapping issues
+          try {
+            Server.logger.info(s"Initializing extraction manager for ${key.extractorClass.getSimpleName} in ${key.language.wikiCode}")
+            manager.updateAll
+            Server.logger.info(s"Successfully initialized extraction manager for ${key.extractorClass.getSimpleName}")
             manager
+          } catch {
+            case e: Exception =>
+              Server.logger.severe(s"Failed to initialize extraction manager for ${key.extractorClass.getSimpleName} in ${key.language.wikiCode}: ${e.getMessage}")
+              e.printStackTrace()
+              throw e
+          }
         }
-      }
-    })
-}
+      })
+  }
 
   // Main extraction manager with ALL extractors
   val extractor: ExtractionManager = {
@@ -85,8 +85,9 @@ private val singleExtractorCache: LoadingCache[ExtractorCacheKey, ExtractionMana
    * Enhanced extract using a specific extractor with Guava caching optimization
    */
   def extractWithSpecificExtractor(source: Source, destination: Destination, language: Language, extractorName: String): Unit = {
-    // Validate language support - this will throw appropriate exceptions
-    val availableExtractors = getAvailableExtractorNames(language)
+    // Use ServerConfiguration methods for validation and extractor lookup
+    val config = Server.config
+    val availableExtractors = config.getAvailableExtractors(language)
 
     // Find the extractor class
     val extractorClass = findExtractorClass(language, extractorName) match {
@@ -122,42 +123,17 @@ private val singleExtractorCache: LoadingCache[ExtractorCacheKey, ExtractionMana
   }
 
   /**
-   * Get available extractor names for a specific language
+   * Get available extractor names for a specific language - delegates to ServerConfiguration
    */
   def getAvailableExtractorNames(language: Language): Seq[String] = {
-    // Check if language is enabled in configuration
-    if (!managers.contains(language)) {
-      throw new IllegalArgumentException(s"Language '${language.wikiCode}' is not enabled in the configuration. Enabled languages: ${managers.keys.map(_.wikiCode).mkString(", ")}")
-    }
-
-    val customExtractorsForLang = customTestExtractors.getOrElse(language, Seq.empty)
-    val allConfiguredExtractors = (mappingTestExtractors ++ customExtractorsForLang).distinct
-    val extractorNames = allConfiguredExtractors.map(_.getSimpleName).sorted
-
-    // Check if we have any extractors for this enabled language
-    if (extractorNames.isEmpty) {
-      throw new IllegalStateException(s"Language '${language.wikiCode}' is enabled in configuration but has no extractors configured. Please check the extractor configuration.")
-    }
-
-    extractorNames
+    Server.config.getAvailableExtractors(language)
   }
 
   /**
-   * Check if a specific extractor is available for a language
+   * Check if a specific extractor is available for a language - delegates to ServerConfiguration
    */
   def isExtractorAvailable(language: Language, extractorName: String): Boolean = {
-    try {
-      // Check if language is enabled in configuration
-      if (!managers.contains(language)) {
-        return false
-      }
-
-      findExtractorClass(language, extractorName).isDefined
-    } catch {
-      case e: Exception =>
-        logger.warning(s"Error checking extractor availability for '$extractorName' in language '${language.wikiCode}': ${e.getMessage}")
-        false
-    }
+    Server.config.isExtractorAvailable(language, extractorName)
   }
 
   /**
@@ -187,6 +163,17 @@ object Server
     private var _instance: Server = _
 
     def instance: Server = _instance
+
+      /**
+     * Returns the Server instance, throwing an exception if not initialized.
+     * This centralizes the null checking logic used throughout the application.
+     */
+    def getInstance(): Server = {
+      if (_instance == null) {
+        throw new IllegalStateException("Server instance is not initialized")
+      }
+      _instance
+    }
 
     private var _config: ServerConfiguration = _
 

--- a/server/src/main/scala/org/dbpedia/extraction/server/ServerConfiguration.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/ServerConfiguration.scala
@@ -96,16 +96,6 @@ class ServerConfiguration(configPath: String) extends Config(configPath) {
     )
   }
 
-  // Helper method for flexible extractor name matching
-  private def matchesExtractorName(extractorMap: Map[String, Class[_ <: Extractor[_]]], extractorName: String): Boolean = {
-    extractorMap.contains(extractorName) ||
-    extractorMap.contains(extractorName.toLowerCase) ||
-    extractorMap.contains(extractorName + "Extractor") ||
-    extractorMap.contains((extractorName + "Extractor").toLowerCase) ||
-    extractorMap.contains(extractorName.replace("Extractor", "")) ||
-    extractorMap.contains(extractorName.replace("Extractor", "").toLowerCase)
-  }
-
   // Helper method for flexible extractor class lookup
   private def findExtractorClass(extractorMap: Map[String, Class[_ <: Extractor[_]]], extractorName: String): Option[Class[_ <: Extractor[_]]] = {
     extractorMap.get(extractorName)
@@ -114,20 +104,6 @@ class ServerConfiguration(configPath: String) extends Config(configPath) {
       .orElse(extractorMap.get((extractorName + "Extractor").toLowerCase))
       .orElse(extractorMap.get(extractorName.replace("Extractor", "")))
       .orElse(extractorMap.get(extractorName.replace("Extractor", "").toLowerCase))
-  }
-
-  // Cached extractor names by language to avoid repeated computation
-  private lazy val extractorNamesByLanguage: Map[Language, Seq[String]] = {
-    val result = languages.map { language =>
-      val customExtractors = customTestExtractorClasses.getOrElse(language, Seq.empty)
-      val allExtractors = (customExtractors ++ mappingTestExtractorClasses)
-        .map(_.getSimpleName)
-        .distinct
-        .sorted
-      language -> allExtractors
-    }.toMap
-
-    result
   }
 
   // Cached extractor classes by language for fast lookup
@@ -164,37 +140,13 @@ class ServerConfiguration(configPath: String) extends Config(configPath) {
   def getAvailableExtractors(language: Language): Seq[String] = {
     validateLanguageEnabled(language)
 
-    val extractors = extractorNamesByLanguage.getOrElse(language, Seq.empty)
-    if (extractors.isEmpty) {
+    val extractorMap = extractorClassesByLanguage.getOrElse(language, Map.empty)
+    if (extractorMap.isEmpty) {
       throw new IllegalStateException(
         s"Language '${language.wikiCode}' is enabled but has no extractors configured. Please check the extractor configuration."
       )
     }
-    extractors
-  }
-
-  // Check if a specific extractor is available for a language using cached lookup
-  def isExtractorAvailable(language: Language, extractorName: String): Boolean = {
-    try {
-      if (!isLanguageEnabled(language)) return false
-
-      val extractorMap = extractorClassesByLanguage.getOrElse(language, Map.empty)
-      matchesExtractorName(extractorMap, extractorName)
-    } catch {
-      case e: Exception =>
-        logger.warning(
-          s"Error checking extractor availability for '$extractorName' in language '${language.wikiCode}': ${e.getMessage}"
-        )
-        false
-    }
-  }
-
-  // Get extractor classes for a specific language
-  def getExtractorClasses(language: Language): Seq[Class[_ <: Extractor[_]]] = {
-    validateLanguageEnabled(language)
-
-    val customExtractors = customTestExtractorClasses.getOrElse(language, Seq.empty)
-    (customExtractors ++ mappingTestExtractorClasses).distinct
+    extractorMap.keys.toSeq.distinct.sorted
   }
 
   // Get a specific extractor class by name for a language with flexible matching
@@ -212,4 +164,17 @@ class ServerConfiguration(configPath: String) extends Config(configPath) {
         None
     }
   }
+
+  // Check if a specific extractor is available for a language using cached lookup
+  def isExtractorAvailable(language: Language, extractorName: String): Boolean = {
+    getExtractorClass(language, extractorName).isDefined
+  }
+
+// Get extractor classes for a specific language
+def getExtractorClasses(language: Language): Seq[Class[_ <: Extractor[_]]] = {
+  validateLanguageEnabled(language)
+
+  val extractorMap = extractorClassesByLanguage.getOrElse(language, Map.empty)
+  extractorMap.values.toSeq.distinct
+}
 }

--- a/server/src/main/scala/org/dbpedia/extraction/server/resources/Extraction.scala
+++ b/server/src/main/scala/org/dbpedia/extraction/server/resources/Extraction.scala
@@ -9,6 +9,7 @@ import javax.ws.rs.core.{Context, HttpHeaders, MediaType, Response}
 import java.util.logging.{Level, Logger}
 
 import scala.xml.Elem
+import scala.io.{Codec, Source}
 import org.dbpedia.extraction.server.Server
 import org.dbpedia.extraction.wikiparser.WikiTitle
 import org.dbpedia.extraction.destinations.{DeduplicatingDestination, WriterDestination}
@@ -40,8 +41,7 @@ class Extraction(@PathParam("lang") langCode : String)
     @Produces(Array("application/xhtml+xml"))
   def get = {
     try {
-      val extractors = Server.config.getAvailableExtractors(language)
-
+val extractors = Server.getInstance().getAvailableExtractorNames(language)
        <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
          {ServerHeader.getHeader("Extractor a page")}
          <body>
@@ -126,11 +126,11 @@ class Extraction(@PathParam("lang") langCode : String)
     }
   }
 
-  /**
-   * Extracts a MediaWiki article
-   */
-  @GET
-  @Path("extract")
+    /**
+     * Extracts a MediaWiki article
+     */
+    @GET
+    @Path("extract")
   def extract(@QueryParam("title") title: String, @QueryParam("revid") @DefaultValue("-1") revid: Long, @QueryParam("format") format: String, @QueryParam("extractors") extractors: String, @Context headers: HttpHeaders): Response = {
     import scala.collection.JavaConverters._
     if (title == null && revid < 0) throw new WebApplicationException(new Exception("title or revid must be given"), Response.Status.NOT_FOUND)
@@ -169,13 +169,13 @@ class Extraction(@PathParam("lang") langCode : String)
     try {
       extractorName match {
         case "mappings" =>
-          Server.instance.extractor.extract(source, destination, language, false)
+          Server.getInstance().extractor.extract(source, destination, language, false)
 
         case "custom" =>
-          Server.instance.extractor.extract(source, destination, language, true)
+          Server.getInstance().extractor.extract(source, destination, language, true)
 
         case specificExtractor =>
-          Server.instance.extractWithSpecificExtractor(source, destination, language, specificExtractor)
+          Server.getInstance().extractWithSpecificExtractor(source, destination, language, specificExtractor)
       }
     } catch {
       case e: IllegalArgumentException =>
@@ -235,7 +235,6 @@ class Extraction(@PathParam("lang") langCode : String)
         case "n-triples" => "application/n-triples"
         case "n-quads" => "application/n-quads"
         case "rdf-json" => MediaType.APPLICATION_JSON
-        case "trix" => MediaType.APPLICATION_XML
         case _ => MediaType.TEXT_PLAIN
       }
     }
@@ -254,7 +253,7 @@ class Extraction(@PathParam("lang") langCode : String)
         val source = XMLSource.fromXML(xml, language)
         val destination = new WriterDestination(() => writer, formatter)
 
-        Server.instance.extractor.extract(source, destination, language)
+        Server.getInstance().extractor.extract(source, destination, language)
 
         writer.toString
     }


### PR DESCRIPTION
The code was enhanced to dynamically load and display available extractors from the server configuration instead of using mappings only vs all extractors options. Users can now select specific extractors individually, with proper validation and a new JSON API endpoint for extractor metadata.